### PR TITLE
ascardlist -> ascard

### DIFF
--- a/lib/wcs_helper.py
+++ b/lib/wcs_helper.py
@@ -126,7 +126,7 @@ def fix_header(header):
     if hasattr(header, "cards"):
         old_cards = header.cards
     else:
-        old_cards = header.ascardlist()
+        old_cards = header.ascard
 
     new_cards = []
 


### PR DESCRIPTION
Simple change, but `ascardlist` is deprecated in astropy and I think removed in the latest version
