### PR TITLE
Update wcs method names

### DIFF
--- a/lib/wcs_helper.py
+++ b/lib/wcs_helper.py
@@ -314,16 +314,16 @@ class ProjectionPywcsNd(_ProjectionSubInterface, ProjectionBase):
 
         xy1 = lon_lat.transpose()
 
-        # somehow, wcs_sky2pix does not work for some cases
-        xy21 = [self._pywcs.wcs_sky2pix([xy11], 1)[0] for xy11 in xy1]
-        #xy21 = self._pywcs.wcs_sky2pix(xy1, 1)
+        # somehow, wcs_world2pix does not work for some cases
+        xy21 = [self._pywcs.wcs_world2pix([xy11], 1)[0] for xy11 in xy1]
+        #xy21 = self._pywcs.wcs_world2pix(xy1, 1)
 
         xy2 = np.array(xy21).transpose()
         return xy2
 
     def toworld(self, xy):
         """ 1, 1 base """
-        xy2 = self._pywcs.wcs_pix2sky(np.asarray(xy).T, 1)
+        xy2 = self._pywcs.wcs_pix2world(np.asarray(xy).T, 1)
 
         lon_lat = xy2.T
         # fixme
@@ -389,7 +389,7 @@ class ProjectionPywcsSub(_ProjectionSubInterface, ProjectionBase):
                 s.fill(self._ref_world[i])
                 xyz[i] = s
 
-        #xyz2 = self._pywcs.wcs_sky2pix(np.asarray(xyz).T, 1)
+        #xyz2 = self._pywcs.wcs_world2pix(np.asarray(xyz).T, 1)
         xyz2 = self.proj.topixel(np.array(xyz))
 
         #xyz2r = [d for (i, d) in enumerate(xyz2) if i in self._axis_nums_to_keep]
@@ -445,12 +445,12 @@ class ProjectionPywcs(ProjectionBase):
 
     def topixel(self, xy):
         """ 1, 1 base """
-        xy2 = self._pywcs.wcs_sky2pix(np.asarray(xy).T, 1)
+        xy2 = self._pywcs.wcs_world2pix(np.asarray(xy).T, 1)
         return xy2.T[:2]
 
     def toworld(self, xy):
         """ 1, 1 base """
-        xy2 = self._pywcs.wcs_pix2sky(np.asarray(xy).T, 1)
+        xy2 = self._pywcs.wcs_pix2world(np.asarray(xy).T, 1)
         return xy2.T[:2]
 
     def sub(self, axes):


### PR DESCRIPTION
This PR updates some  `WCS` method names that were deprecated a long time ago and will be removed in the upcoming Astropy 0.4 release:
https://github.com/astropy/astropy/pull/2386
