### PR TITLE
get_mask bug fix: header<->origin

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -170,23 +170,17 @@ def read_region_as_imagecoord(s, header):
     return rp.filter_shape(sss3)
 
 
-
-def get_mask(region, hdu):
+def get_mask(region, hdu, origin=1):
     """
     f = pyfits.read("test.fits")
     reg = read_region_as_imagecoord(s, f[0].header)
     mask = get_mask(reg, f[0])
     """
-
     from pyregion.region_to_filter import as_region_filter
 
     data = hdu.data
-    header = hdu.header
-
-    region_filter = as_region_filter(region, header=header)
-
+    region_filter = as_region_filter(region, origin=origin)
     mask = region_filter.mask(data)
-
     return mask
 
 


### PR DESCRIPTION
Fixes a bug in `get_mask` function where a header was passed to `as_region_filter` as `origin` argument.

This replaces a part of the PR #29.
