### PR TITLE
Allow selection of the axis for angle measurement to the North

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -25,7 +25,7 @@ class ShapeList(list):
         else:
             return True
 
-    def as_imagecoord(self, header):
+    def as_imagecoord(self, header, rot_wrt_axis=1):
         """
         Return a new ShapeList where the coordinate of the each shape
         is converted to the image coordinate using the given header
@@ -37,7 +37,7 @@ class ShapeList(list):
             comment_list = cycle([None])
 
         r = RegionParser.sky_to_image(zip(self, comment_list),
-                                      header)
+                                      header, rot_wrt_axis=rot_wrt_axis)
         shape_list, comment_list = zip(*list(r))
         return ShapeList(shape_list, comment_list=comment_list)
 
@@ -60,7 +60,7 @@ class ShapeList(list):
 
         return patches, txts
 
-    def get_filter(self, header=None, origin=1):
+    def get_filter(self, header=None, origin=1, rot_wrt_axis=1):
         """
         Often, the regions files implicitly assume the lower-left
         corner of the image as a coordinate (1,1). However, the python
@@ -77,14 +77,14 @@ class ShapeList(list):
                 raise RuntimeError("the region has non-image coordinate. header is required.")
             reg_in_imagecoord = self
         else:
-            reg_in_imagecoord = self.as_imagecoord(header)
+            reg_in_imagecoord = self.as_imagecoord(header, rot_wrt_axis=rot_wrt_axis)
 
         region_filter = as_region_filter(reg_in_imagecoord, origin=1)
 
         return region_filter
 
 
-    def get_mask(self, hdu=None, header=None, shape=None):
+    def get_mask(self, hdu=None, header=None, shape=None, rot_wrt_axis=1):
         """
         creates a 2-d mask.
 
@@ -98,7 +98,7 @@ class ShapeList(list):
         if hdu and shape is None:
             shape = hdu.data.shape
 
-        region_filter = self.get_filter(header=header)
+        region_filter = self.get_filter(header=header, rot_wrt_axis=rot_wrt_axis)
         mask = region_filter.mask(shape)
 
         return mask
@@ -160,12 +160,12 @@ def read_region(s):
     return rp.filter_shape(sss2)
 
 
-def read_region_as_imagecoord(s, header):
+def read_region_as_imagecoord(s, header, rot_wrt_axis=1):
     rp = RegionParser()
     ss = rp.parse(s)
     sss1 = rp.convert_attr(ss)
     sss2 = _check_wcs(sss1)
-    sss3 = rp.sky_to_image(sss2, header)
+    sss3 = rp.sky_to_image(sss2, header, rot_wrt_axis=rot_wrt_axis)
 
     return rp.filter_shape(sss3)
 

--- a/lib/ds9_region_parser.py
+++ b/lib/ds9_region_parser.py
@@ -170,7 +170,7 @@ class RegionParser(RegionPusher):
 
 
     @staticmethod
-    def sky_to_image(l, header):
+    def sky_to_image(l, header, rot_wrt_axis=1):
 
         try:
             header["NAXIS"]
@@ -205,14 +205,17 @@ class RegionParser(RegionPusher):
                 xy0 = None
 
                 cl1, fl1 = cl[:n1], fl[:n1]
-                cl10, xy0 = convert_to_imagecoord(cl1, fl1, wcs_proj, sky_to_sky, xy0)
+                cl10, xy0 = convert_to_imagecoord(cl1, fl1, wcs_proj,
+                                sky_to_sky, xy0, rot_wrt_axis=rot_wrt_axis)
 
                 nn2 = len(cl)-(len(fl) - n2)
                 cl2, fl2 = cl[n1:nn2], fl[n1:n2]
-                cl20, xy0 = convert_to_imagecoord(cl2, fl2, wcs_proj, sky_to_sky, xy0)
+                cl20, xy0 = convert_to_imagecoord(cl2, fl2, wcs_proj,
+                                sky_to_sky, xy0, rot_wrt_axis=rot_wrt_axis)
 
                 cl3, fl3 = cl[nn2:], fl[n2:]
-                cl30, xy0 = convert_to_imagecoord(cl3, fl3, wcs_proj, sky_to_sky, xy0)
+                cl30, xy0 = convert_to_imagecoord(cl3, fl3, wcs_proj,
+                                sky_to_sky, xy0, rot_wrt_axis=rot_wrt_axis)
 
                 new_cl = cl10 + cl20 + cl30
 
@@ -227,7 +230,7 @@ class RegionParser(RegionPusher):
 
                 if pc is None:
                     raise RuntimeError("Physical coordinate is not known.")
-                
+
                 cl = l1.coord_list
                 fl = ds9_shape_defs[l1.name].args_list
 
@@ -243,12 +246,14 @@ class RegionParser(RegionPusher):
 
                 cl1, fl1 = cl[:n1], fl[:n1]
                 cl10 = convert_physical_to_imagecoord(cl1, fl1, pc)
-                #cl10, xy0 = convert_to_imagecoord(cl1, fl1, wcs_proj, sky_to_sky, xy0)
+                #cl10, xy0 = convert_to_imagecoord(cl1, fl1, wcs_proj,
+                #                sky_to_sky, xy0, rot_wrt_axis=rot_wrt_axis)
 
                 nn2 = len(cl)-(len(fl) - n2)
                 cl2, fl2 = cl[n1:nn2], fl[n1:n2]
                 cl20 = convert_physical_to_imagecoord(cl2, fl2, pc)
-                #cl20, xy0 = convert_to_imagecoord(cl2, fl2, wcs_proj, sky_to_sky, xy0)
+                #cl20, xy0 = convert_to_imagecoord(cl2, fl2, wcs_proj,
+                #                sky_to_sky, xy0, rot_wrt_axis=rot_wrt_axis)
 
                 cl3, fl3 = cl[nn2:], fl[n2:]
                 cl30 = convert_physical_to_imagecoord(cl3, fl3, pc)

--- a/lib/wcs_converter.py
+++ b/lib/wcs_converter.py
@@ -6,7 +6,7 @@ from .region_numbers import SimpleNumber, SimpleInteger
 import copy
 
 
-def convert_to_imagecoord(cl, fl, wcs_proj, sky_to_sky, xy0):
+def convert_to_imagecoord(cl, fl, wcs_proj, sky_to_sky, xy0, rot_wrt_axis=1):
     fl0 = fl
     new_cl = []
 
@@ -23,14 +23,18 @@ def convert_to_imagecoord(cl, fl, wcs_proj, sky_to_sky, xy0):
             cl = cl[2:]
             fl = fl[2:]
         elif fl[0] == Distance:
-            degree_per_pixel = estimate_cdelt(wcs_proj,
-                                              *xy0)
+            degree_per_pixel = estimate_cdelt(wcs_proj, *xy0)
             new_cl.append(cl[0]/degree_per_pixel)
             cl = cl[1:]
             fl = fl[1:]
         elif fl[0] == Angle:
             rot1, rot2 = estimate_angle(wcs_proj, xy0[0], xy0[1], sky_to_sky)
-            new_cl.append(cl[0]+rot1-180.)
+            if rot_wrt_axis == 1:
+                # use the angle between the X axis and North
+                new_cl.append(cl[0]+rot1-180.)
+            else:
+                # use the angle between the Y axis and North
+                new_cl.append(cl[0]+rot2-90.)
             cl = cl[1:]
             fl = fl[1:]
         else:


### PR DESCRIPTION
`pyregion` computes the image rotation angle using as the angle between North and X-axis instead of typically adopted convention of using Y-axis for image orientation computations. This produces regions that are rotated compared to the regions produced by DS9 when image axes are non-orthogonal (at least for HST images). The proposed here fix consists in introducing an additional parameter `rot_wrt_axis` (can take values 1 or 2) to let users select what axis should be used for computing image rotations (-> rotations of regions). For example, by setting `rot_wrt_axis=2`, `pyregion` now will use `rot2` (angle between Y-axis and North) instead of `rot1` (in `wcs_converter.py`) in computing region rotations.

This replaces a part of the PR #29.
