### PR TITLE
Update version requirements to allow pyparsing 2.0.1 for py 2.6,2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,11 @@ for line in open('lib/version.py').readlines():
 def main():
     if sys.version_info[0] >= 3:
         install_requires = ['pyparsing>=2.0.0']
+    elif sys.version_info[:2] >= (2, 6):
+        # For Python 2.6 and 2.7, any version *except* 2.0.0 will work
+        install_requires = ['pyparsing!=2.0.0']
     else:
-        # pyparsing >= 2.0.0 is not compatible with Python 2
+        # For Python < 2.6, a version before 2.0.0 is required
         install_requires = ['pyparsing<2.0.0']
 
     ka = dict(name = "pyregion",


### PR DESCRIPTION
According to http://pyparsing.wikispaces.com/ the latest version 2.0.1 of pyparsing will work with python 2.6 and 2.7.  This updates the setup.py requirements accordingly.  There is an odd requirement for python 2.6 and 2.7 of allowing any version _except_ 2.0.0.
