### PR TITLE
Fix setuptool configuation problem with Python 3. The issue is that it d...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-from distribute_setup import use_setuptools
-use_setuptools()
-
 from setuptools import setup, Extension
 
 # check if cython or pyrex is available.


### PR DESCRIPTION
...ownloads setuptools and runs 2to3 on it. It does not work. There are packages for setuptools in python 3 so this should not be required
