### PR TITLE
Use readthedocs Sphinx html theme locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ install:
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_INSTALL sphinx_rtd_theme; fi
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_INSTALL wcsaxes; fi
 
     # COVERAGE DEPENDENCIES

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,3 +159,14 @@ if eval(setup_cfg.get('edit_on_github')):
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
+
+# on_rtd is whether we are on readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+


### PR DESCRIPTION
The `pyregion` html docs locally look ugly because they use the default theme.

@astrofrog What needs to be done to get the readthedocs Sphinx html theme locally?
Just change `docs/conf.py` settings or bundle the readthedocs theme somehow?
