### PR TITLE
Opting out raising deprecations are errors

### DIFF
--- a/pyregion/conftest.py
+++ b/pyregion/conftest.py
@@ -16,7 +16,8 @@ except NameError:
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
-enable_deprecations_as_exceptions()
+# Deprecations are coming from upstream kapteyn, switching it off for now
+#enable_deprecations_as_exceptions()
 
 # Add astropy to test header information and remove unused packages.
 # Pytest header customisation was introduced in astropy 1.0.


### PR DESCRIPTION
Kapteyn throws deprecation warnings, but since there is an outstanding PR (#54) that get rids of it, I think it may not be worth dealing with this now. However I'll open a low prio issue for it.

