### PR TITLE
fix parsing error for a space before angular distance

### DIFF
--- a/pyregion/region_numbers.py
+++ b/pyregion/region_numbers.py
@@ -181,8 +181,8 @@ dms_number = _dms_number()
 
 
 def _angular_distance():
-    _m = (usn + Literal("\'")).leaveWhitespace()
-    _s = (usn + Literal("\"")).leaveWhitespace()
+    _m = (usn + Literal("\'").leaveWhitespace())
+    _s = (usn + Literal("\"").leaveWhitespace())
 
     ms = Or([_m + Optional(_s), _s])
 

--- a/pyregion/tests/test_ds9_region_parser.py
+++ b/pyregion/tests/test_ds9_region_parser.py
@@ -44,3 +44,19 @@ def test_global():
     ss = rp.parseLine(s)[0]
 
     assert isinstance(ss[0], Global)
+
+
+def test_space_delimited_region():
+    s = 'J2000; circle 188.5557102 12.0314056 1" # color=red'
+
+    rp = RegionParser()
+    ss = rp.parseLine(s)[0]
+
+    from ..parser_helper import CoordCommand, Shape
+    assert isinstance(ss[0], CoordCommand)
+    assert ss[0].text == "J2000"
+
+    from ..region_numbers import SimpleNumber, AngularDistance
+    assert isinstance(ss[1], Shape)
+    assert map(type, ss[1].params) == [SimpleNumber, SimpleNumber,
+                                       AngularDistance]


### PR DESCRIPTION
This is to fix a parser raising an error when there is a space before the AngularDistance (e.g., 1").
This should solve #73.
