### PR TITLE
Add `long_description` for PyPI and link to Astropy regions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,10 @@ Status
 
 .. image:: https://coveralls.io/repos/astropy/pyregion/badge.svg?branch=master
     :target: https://coveralls.io/r/astropy/pyregion
+
+New regions package
+-------------------
+
+See also the in-development `regions` package
+at https://github.com/astropy/regions
+a new astronomy package for regions based on Astropy.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,12 @@ pyregion
 pyregion is a python module to parse ds9 region files. It also supports
 ciao region files.
 
+.. note::
+
+    See also the in-development ``regions`` package
+    at https://github.com/astropy/regions
+    a new astronomy package for regions based on Astropy.
+
 
 +----------------------------------------+----------------------------------------+
 | ds9                                    | pyregion + matplotlib                  |

--- a/pyregion/__init__.py
+++ b/pyregion/__init__.py
@@ -1,5 +1,12 @@
 """
 pyregion: a Python parser for ds9 region files
+
+* Code : https://github.com/astropy/pyregion
+* Docs : http://pyregion.readthedocs.io/
+
+See also the in-development `regions` package
+at https://github.com/astropy/regions
+a new astronomy package for regions based on Astropy.
 """
 
 # Affiliated packages may add whatever they like to this file, but


### PR DESCRIPTION
This PR:
- adds link to code and repo in `__init__` docstring, which is what gets shows PyPI via `long_description` in `setup.py`.
- Adds a link to the new Astropy regions package from the README and top-level docs page.

@leejjoon - Is this OK with you or do you prefer something different?