### PR TITLE
Document rot_wrt_axis parameter

### DIFF
--- a/pyregion/core.py
+++ b/pyregion/core.py
@@ -52,8 +52,8 @@ class ShapeList(list):
         ----------
         header : `~astropy.io.fits.Header`
             FITS header
-        rot_wrt_axis : bool
-            Rotate with respect to the image axis?
+        rot_wrt_axis : {1, 2}
+            Use rotation with respect to axis 1 (X-axis) or axis 2 (Y-axis) and north.
 
         Returns
         -------
@@ -91,13 +91,28 @@ class ShapeList(list):
         return patches, txts
 
     def get_filter(self, header=None, origin=1, rot_wrt_axis=1):
-        """
+        """Get filter.
+
         Often, the regions files implicitly assume the lower-left
         corner of the image as a coordinate (1,1). However, the python
         convetion is that the array index starts from 0. By default
         (``origin=1``), coordinates of the returned mpl artists have
         coordinate shifted by (1, 1). If you do not want this shift,
         use ``origin=0``.
+
+        Parameters
+        ----------
+        header : `astropy.io.fits.Header`
+            FITS header
+        origin : {0, 1}
+            Pixel coordinate origin
+        rot_wrt_axis : {1, 2}
+            Use rotation with respect to axis 1 (X-axis) or axis 2 (Y-axis) and north.
+
+        Returns
+        -------
+        filter : TODO
+            Filter object
         """
 
         from .region_to_filter import as_region_filter
@@ -124,8 +139,8 @@ class ShapeList(list):
             FITS header
         shape : tuple
             Image shape
-        rot_wrt_axis : bool
-            Rotate with respect to the image axis?
+        rot_wrt_axis : {1, 2}
+            Use rotation with respect to axis 1 (X-axis) or axis 2 (Y-axis) and north.
 
         Returns
         -------
@@ -282,8 +297,8 @@ def read_region_as_imagecoord(s, header, rot_wrt_axis=1):
         Region string
     header : `~astropy.io.fits.Header`
         FITS header
-    rot_wrt_axis : bool
-        Rotate with respect to the image axis?
+    rot_wrt_axis : {1, 2}
+        Use rotation with respect to axis 1 (X-axis) or axis 2 (Y-axis) and north.
 
     Returns
     -------

--- a/pyregion/ds9_region_parser.py
+++ b/pyregion/ds9_region_parser.py
@@ -162,6 +162,21 @@ class RegionParser(RegionPusher):
 
     @staticmethod
     def sky_to_image(l, header, rot_wrt_axis=1):
+        """
+
+        Parameters
+        ----------
+        l : TODO
+            TODO
+        header : `~astropy.io.fits.Header`
+            FITS header
+        rot_wrt_axis : {1, 2}
+            Use rotation with respect to axis 1 (X-axis) or axis 2 (Y-axis) and north.
+
+        Returns
+        -------
+        TODO
+        """
 
         try:  # this is a hack to test if header is fits header of wcs object.
             header["NAXIS"]

--- a/pyregion/wcs_converter.py
+++ b/pyregion/wcs_converter.py
@@ -32,9 +32,11 @@ def convert_to_imagecoord(cl, fl, wcs_proj, sky_to_sky, xy0, rot_wrt_axis=1):
             if rot_wrt_axis == 1:
                 # use the angle between the X axis and North
                 new_cl.append(cl[0]+rot1-180.)
-            else:
+            elif rot_wrt_axis == 2:
                 # use the angle between the Y axis and North
                 new_cl.append(cl[0]+rot2-90.)
+            else:
+                raise ValueError('Invalid rot_wrt_axis: {}. Allowed values: 1 or 2.'.format(rot_wrt_axis))
             cl = cl[1:]
             fl = fl[1:]
         else:


### PR DESCRIPTION
This is a minor cleanup to make `rot_wrt_axis` default keyword arguments bool instead of int, to make it clearer that this is a flag (and not e.g. a float rotation angle).

@leejjoon - OK?