### PR TITLE
Remove read_region and from public API?

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,3 +3,5 @@ Reference/API
 
 .. automodapi:: pyregion
    :no-inheritance-diagram:
+   :no-heading:
+   :skip: cycle, RegionParser, read_region, read_region_as_imagecoord

--- a/examples/demo_print_region.py
+++ b/examples/demo_print_region.py
@@ -1,38 +1,35 @@
-from pyregion import read_region, read_region_as_imagecoord
-
-import math
-
+"""Example how to read and print regions.
+"""
 from astropy.io.fits import Header
+import pyregion
 
-def test_header():
-    return Header.fromtextfile("test.header")
 
-def print_region(r):
-    for i, l in enumerate(r):
-        print("[region %d]" % (i+1))
+def print_shape_list(shape_list):
+    for idx, shape in enumerate(shape_list, start=1):
+        print("[region %d]" % idx)
         print()
-        print("%s; %s(%s)" % (l.coord_format,
-                              l.name,
-                              ", ".join([str(s) for s in l.coord_list])))
+        print("%s; %s(%s)" % (shape.coord_format,
+                              shape.name,
+                              ", ".join([str(s) for s in shape.coord_list])))
 
-        print(l.attr[0])
-        print(", ".join(["%s=%s" % (k, v.strip()) for k, v in list(l.attr[1].items())]))
+        print(shape.attr[0])
+        print(", ".join(["%s=%s" % (k, v.strip()) for k, v in list(shape.attr[1].items())]))
         print()
+
 
 if __name__ == "__main__":
     print("** coordinate in FK5 **")
     print()
-    region_name = "test01_print.reg"
-    #region_name = "test_text.reg"
-    #region_name = "test01.reg"
-    r = read_region(open(region_name).read())
-    print_region(r)
+    filename = "test01_print.reg"
+    # filename = "test_text.reg"
+    # filename = "test01.reg"
+    shape_list = pyregion.open(filename)
+    print_shape_list(shape_list)
 
     print()
     print()
     print("** coordinate in image **")
     print()
-    header = test_header()
-    r = read_region_as_imagecoord(open(region_name).read(), header)
-    print_region(r)
-
+    header = Header.fromtextfile("test.header")
+    shape_list2 = shape_list.as_imagecoord(header=header)
+    print_shape_list(shape_list2)

--- a/pyregion/__init__.py
+++ b/pyregion/__init__.py
@@ -11,4 +11,4 @@ from ._astropy_init import *
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
     from .core import *
-    from .parser_helper import *
+    from .parser_helper import Shape

--- a/pyregion/core.py
+++ b/pyregion/core.py
@@ -3,15 +3,6 @@ from itertools import cycle
 from .ds9_region_parser import RegionParser
 from .wcs_converter import check_wcs as _check_wcs
 
-__all__ = [
-    'ShapeList',
-    'parse',
-    'open',
-    'read_region',
-    'read_region_as_imagecoord',
-    'get_mask',
-]
-
 _builtin_open = open
 
 
@@ -21,7 +12,7 @@ class ShapeList(list):
     Parameters
     ----------
     shape_list : list
-        List of 'pyregion.Shape' objects
+        List of `pyregion.Shape` objects
     comment_list : list, None
         List of comment strings for each argument
     """

--- a/pyregion/core.py
+++ b/pyregion/core.py
@@ -16,12 +16,12 @@ _builtin_open = open
 
 
 class ShapeList(list):
-    """A list of shape objects.
+    """A list of `~pyregion.Shape` objects.
 
     Parameters
     ----------
     shape_list : list
-        List of 'pyregion.parse_helper.Shape' objects
+        List of 'pyregion.Shape' objects
     comment_list : list, None
         List of comment strings for each argument
     """
@@ -232,7 +232,7 @@ def parse(region_string):
     Returns
     -------
     shapes : `ShapeList`
-        List of shapes
+        List of `~pyregion.Shape`
     """
     rp = RegionParser()
     ss = rp.parse(region_string)
@@ -254,7 +254,7 @@ def open(fname):
     Returns
     -------
     shapes : `ShapeList`
-        List of shapes
+        List of `~pyregion.Shape`
     """
     region_string = _builtin_open(fname).read()
     return parse(region_string)
@@ -270,15 +270,16 @@ def read_region(s):
 
     Returns
     -------
-    shapes : list
-        List of shapes
+    shapes : `ShapeList`
+        List of `~pyregion.Shape`
     """
     rp = RegionParser()
     ss = rp.parse(s)
     sss1 = rp.convert_attr(ss)
     sss2 = _check_wcs(sss1)
 
-    return rp.filter_shape(sss2)
+    shape_list = rp.filter_shape(sss2)
+    return ShapeList(shape_list)
 
 
 def read_region_as_imagecoord(s, header, rot_wrt_axis=1):
@@ -295,7 +296,7 @@ def read_region_as_imagecoord(s, header, rot_wrt_axis=1):
 
     Returns
     -------
-    shapes : list
+    shapes : `~pyregion.ShapeList`
         List of `~pyregion.Shape`
     """
     rp = RegionParser()
@@ -304,7 +305,8 @@ def read_region_as_imagecoord(s, header, rot_wrt_axis=1):
     sss2 = _check_wcs(sss1)
     sss3 = rp.sky_to_image(sss2, header, rot_wrt_axis=rot_wrt_axis)
 
-    return rp.filter_shape(sss3)
+    shape_list = rp.filter_shape(sss3)
+    return ShapeList(shape_list)
 
 
 def get_mask(region, hdu, origin=1):
@@ -312,7 +314,7 @@ def get_mask(region, hdu, origin=1):
 
     Parameters
     ----------
-    region : list
+    region : `~pyregion.ShapeList`
         List of `~pyregion.Shape`
     hdu : `~astropy.io.fits.ImageHDU`
         FITS image HDU

--- a/pyregion/parser_helper.py
+++ b/pyregion/parser_helper.py
@@ -2,10 +2,6 @@ from pyparsing import (Literal, CaselessKeyword, Optional, OneOrMore,
                        ZeroOrMore, restOfLine, MatchFirst, And, Or)
 
 
-__all__ = [
-    'Shape',
-]
-
 def as_comma_separated_list(al):
 
     l = [al[0]]


### PR DESCRIPTION
In #83 I added [read_region](http://pyregion.readthedocs.io/en/latest/api/pyregion.read_region.html) and [read_region_as_imagecoord](http://pyregion.readthedocs.io/en/latest/api/pyregion.read_region_as_imagecoord.html)
to the public API by listing them in `__all__` in `pyregion/core.py`.

@leejjoon and all -- Should they be part of the public API or be deprecated or removed?

As far as I can see, `read_region` is very similar in purpose to [parse](http://pyregion.readthedocs.io/en/latest/api/pyregion.parse.html), although the implementation is different. `read_region_as_imagecoord` isn't really needed either, one can use `parse` followed by [ShapeList.as_imagecoord](http://pyregion.readthedocs.io/en/latest/api/pyregion.ShapeList.html#pyregion.ShapeList.as_imagecoord).

The current [Getting started](http://pyregion.readthedocs.io/en/latest/getting_started.html) does explain `parse` and `ShapeList.as_imagecoord`, but never mentions `read_region` or `read_region_as_imagecoord`.

IMO the current `pyregion` API is a bit special anyways compared to other Python packages.
- `open` doesn't just open, but also reads and parses. In Astropy this would be a classmethod `ShapeList.read`.
-  `read_region` doesn't read from a file, it takes a string and just parses it.

I guess the options are
- remove or change some things
- deprecate
- keep everything as is and document a bit what's what (maybe just not include `read_region` and `read_region_as_imagecoord` in the HTML API docs to discourage their use)?
- ....?

@leejjoon  and heavy `pyregion` users like @keflavich - Thoughts?