### PR TITLE
Add CHANGES.rst and changelog.rst for docs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,0 @@
-2014-05-28 Merged a PR #26. This will change the type of 'tag'
-	attrubite from a string to a list of strings.
-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,37 @@
+2.0 (unreleased)
+----------------
+
+- tbd
+
+1.2 (unreleased)
+----------------
+
+- https://pypi.org/project/pyregion/1.2/
+- The changelog for this release is incomplete.
+- We'll start collecting a complete changelog starting after this release.
+
+- This release brings major changes to the code, docs and test setup,
+  the package was converted to an Astropy affiliated package.
+- There are only a few bugfixes and there should be very few breaking changes,
+  this should be a mostly backwards-compatible release.
+
+
+1.1.4 (Oct 26, 2014)
+--------------------
+
+- https://pypi.org/project/pyregion/1.1.4/
+- The changelog for this release is incomplete.
+
+- Change tag attribute from string to list of strings [26]
+
+1.1 (March 15, 2013)
+--------------------
+
+- https://pypi.org/project/pyregion/1.1/
+- No changelog available
+
+1.0 (Sep 14, 2010)
+------------------
+
+- https://pypi.org/project/pyregion/1.0/
+- First stable release

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,7 @@
+.. _changelog:
+
+*********
+Changelog
+*********
+
+.. include:: ../CHANGES.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Documentation
    getting_started
    examples
    api
+   changelog
 
 .. note::
   *pyregion* is rather slow, likely due to a inefficient parser.


### PR DESCRIPTION
This PR adds a changelog to pyregion, in the same style that's used for Astropy and all affiliated packages.

I'm merging this now.

I didn't go through the old pull requests and fill the changelog for the upcoming 1.2 or older releases. My suggestion would be that this is something we start to fill going forward from now on.

But of course, if someone wants to add things to the changelog ... pull requests are welcome any time, especially for backward-incompatible changes and fixed bugs.