### PR TITLE
Adding conda channels to CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
         - CONDA_DEPENDENCIES='matplotlib pyparsing Cython'
         - SETUP_CMD='test'
         - SETUP_XVFB=True
+        - CONDA_CHANNELS='astropy-ci-extras'
 
     matrix:
         - SETUP_CMD='egg_info'


### PR DESCRIPTION
Conda channels now need to be explicitly listed, ci-helpers won't add astropy and astropy-ci-extras by default in the future astropy/ci-helpers#128.