### PR TITLE
Improve setup.py and install docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,82 +4,74 @@
 Installation
 ************
 
-Instructions
-============
-
-*pyregion* is registered in pypi, thus you can install it by ::
-
- pip install pyregion
-
-This will also install pyparsing if not installed.
-
-The source file can be downloaded directly from the following page.
-
-* `PyPI page <https://pypi.python.org/pypi/pyregion>`__
-
-To install with necessary dependency (pyparsing, see below), you may do
-
-* in Python 2 ::
-
-    pip install "pyparsing<2"
-    pip install pyregion
-
-* in Python 3 ::
-
-    pip install "pyparsing>=2"
-    pip install pyregion
-
-The development version of pyregion can be found on the github page.
-
-* `Download <http://github.com/astropy/pyregion>`__
-
-To fetch the source
-code by cloning my git repository for any recent bug fix. ::
-
-    git clone git://github.com/astropy/pyregion.git
-    cd pyregion
-    python setup.py install
-
-For any bug reporting or any suggestion, please use the github issue
-tracker.
-
 Dependencies
 ============
 
-**Requirements**
+Python 2.7 and 3.4+ are supported.
 
-Being based on pyparsing module, pyparsing need to be installed to use
-pyregion. Optionally, you also requires pywcs
-module installed for coordinate
-conversion. Displaying regions is supported for matplotlib.  Some
-example uses wcsaxes.
+``pyregion`` has the following required dependencies:
 
-By default, pyregion build a filtering module, which requires a C compiler.
-If you don't want, edit "setup.py" ::
+* `Astropy <http://www.astropy.org/>`__ version 1.0 or later (which requires Numpy)
+* ``pyparsing`` version 2.0 or later for parsing the DS9 region files
+    * `Homepage <http://pyparsing.wikispaces.com/>`__
+    * `PyPI page <https://pypi.python.org/pypi/pyparsing>`__
 
-  WITH_FILTER = False
+``pyregion`` has the following optional dependencies for plotting:
 
+* `matplotlib <http://matplotlib.org/>`__
+* `wcsaxes <https://github.com/astrofrog/wcsaxes>`__
 
-pyparsing
+To work with the development version, you'll need Cython and a C compiler,
+because the code to generate masks from regions is written in Cython.
+
+Stable version
+==============
+
+Installing the latest stable version is possible either using pip or conda.
+
+Using pip
 ---------
-* REQUIRED
-* `Homepage <http://pyparsing.wikispaces.com/>`__
-* `PyPI page <https://pypi.python.org/pypi/pyparsing>`__
-* pyparsing version >= 2.0 suports Python 3. But it seems that it does
-  not support Python 2.
-* For Python 2, install older version (v1.5.7).
 
-astropy
--------
-* REQUIRED
-* `Astropy <https://github.com/astropy/astropy/>`__
+To install pyregion with `pip <http://www.pip-installer.org/en/latest/>`_
+from `PyPI <https://pypi.python.org/pypi/pyregion>`_
+simply run::
 
-matplotlib
-----------
-* OPTIONAL
-* `Homepage <http://matplotlib.org/>`__
+    pip install --no-deps pyregion
 
-wcsaxes
--------
-* OPTIONAL
-* `Homepage <https://github.com/astrofrog/wcsaxes>`__
+.. note::
+
+    The ``--no-deps`` flag is optional, but highly recommended if you already
+    have Numpy installed, since otherwise pip will sometimes try to "help" you
+    by upgrading your Numpy installation, which may not always be desired.
+
+Using conda
+-----------
+
+To install regions with `Anaconda <https://www.continuum.io/downloads>`_
+from the `astropy channel on anaconda.org <https://anaconda.org/astropy/pyregion>`__
+simply run::
+
+    conda install -c astropy pyregion
+
+
+Testing installation
+--------------------
+
+To check if your install is OK, run the tests:
+
+.. code-block:: bash
+
+    python -c 'import pyregion; pyregion.test()'
+
+Development version
+===================
+
+Install the latest development version from https://github.com/astropy/pyregion :
+
+.. code-block:: bash
+
+    git clone https://github.com/astropy/pyregion
+    cd pyregion
+    python setup.py install
+    python setup.py test
+    python setup.py build_sphinx

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 import ah_bootstrap
 from setuptools import setup
 
-#A dirty hack to get around some early import/configurations ambiguities
+# A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
     import builtins
 else:
@@ -68,7 +68,6 @@ generate_version_py(PACKAGENAME, VERSION, RELEASE,
 scripts = [fname for fname in glob.glob(os.path.join('scripts', '*'))
            if os.path.basename(fname) != 'README.rst']
 
-
 # Get configuration information from all of the various subpackages.
 # See the docstring for setup_helpers.update_package_files for more
 # details.
@@ -90,13 +89,28 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
-if sys.version_info[0] >= 3:
-    install_requires = ['pyparsing>=2.0.0']
-else:
-    # For Python 2.6 and 2.7, any version *except* 2.0.0 will work
-    install_requires = ['pyparsing!=2.0.0']
+install_requires = [
+    'pyparsing>=2.0'
+    'numpy',
+    'Cython',
+    'astropy>=1.0',
+]
 
-install_requires += ['astropy>=1.0.0', 'numpy', 'Cython']
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: MacOS :: MacOS X',
+    'Operating System :: POSIX :: Linux',
+    'Programming Language :: Cython',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Topic :: Scientific/Engineering :: Astronomy',
+]
 
 setup(name=PACKAGENAME,
       version=VERSION,
@@ -112,15 +126,6 @@ setup(name=PACKAGENAME,
       cmdclass=cmdclassd,
       zip_safe=False,
       use_2to3=False,
-      classifiers=['Development Status :: 5 - Production/Stable',
-                   'Intended Audience :: Science/Research',
-                   'License :: OSI Approved :: MIT License',
-                   'Operating System :: MacOS :: MacOS X',
-                   'Operating System :: POSIX :: Linux',
-                   'Programming Language :: Cython',
-                   'Programming Language :: Python',
-                   'Programming Language :: Python :: 3',
-                   'Topic :: Scientific/Engineering :: Astronomy',
-                   ],
+      classifiers=classifiers,
       **package_info
-)
+      )


### PR DESCRIPTION
This PR:

- Simplifies `setup.py` to just require `pyparsing>=2.0` and make it clear that we only support Python 2.7 and 3.4+. As far as I can see, pyparsing>=2.0 should just work on Python 2.7 and 3.4+, it's no longer necessary to require different pyparsing versions for Python 2 and 3.
- Rewrites the installation page to make it (hopefully) better:
  - Simplified description of dependencies
  - Separate instructions how to install stable and dev version
  - Add instructions for conda install
  - Add instructions how to run tests
