### PR TITLE
Update astropy-helpers to v1.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
 
 python:
     - 2.7
-    - 3.4
     - 3.5
 
 env:
@@ -54,6 +53,8 @@ matrix:
           env: ASTROPY_VERSION=lts
 
         # Try older numpy versions
+        - python: 3.4
+          env: NUMPY_VERSION=1.11
         - python: 2.7
           env: NUMPY_VERSION=1.10
         - python: 2.7

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -151,7 +151,7 @@ Draw Regions with Matplotlib
 
 pyregion can help you draw ds9 regions with matplotlib.
 `ShapeList.get_mpl_patches_texts <pyregion.ShapeList.get_mpl_patches_texts>` returns a list of
-`matplotlib.artist.Artist` objects ::
+``matplotlib.artist.Artist`` objects ::
 
     r2 = pyregion.parse(region_string).as_imagecoord(f[0].header)
     patch_list, artist_list = r2.get_mpl_patches_texts()


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v1.3.1. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed.

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!*