### PR TITLE
Another small writer fix

### DIFF
--- a/pyregion/core.py
+++ b/pyregion/core.py
@@ -169,7 +169,7 @@ class ShapeList(list):
             print("WARNING: The region list is empty. The region file "
                   "'{:s}' will be empty.".format(outfile))
             try:
-                outf = open(outfile, 'w')
+                outf = _builtin_open(outfile, 'w')
                 outf.close()
                 return
             except IOError as e:


### PR DESCRIPTION
From the commit:
another fix to the writer: the `open` function only accepts one argument.  How
did this *ever* work?