### PR TITLE
Fix grammar

### DIFF
--- a/pyregion/ds9_attr_parser.py
+++ b/pyregion/ds9_attr_parser.py
@@ -39,6 +39,8 @@ class Ds9AttrParser(object):
                                          vector=wcs_shape(CoordOdd, CoordEven,
                                                           Distance, Angle),
                                          composite=wcs_shape(CoordOdd, CoordEven, Angle),
+                                         ruler=wcs_shape(CoordOdd, CoordEven, CoordOdd, CoordEven),
+                                         compass=wcs_shape(CoordOdd, CoordEven, Distance),
                                          projection=wcs_shape(CoordOdd, CoordEven, CoordOdd, CoordEven, Distance),
                                          segment=wcs_shape(CoordOdd, CoordEven,
                                                            repeat=(0, 2)),

--- a/pyregion/ds9_attr_parser.py
+++ b/pyregion/ds9_attr_parser.py
@@ -26,6 +26,17 @@ def get_ds9_attr_parser():
     return ZeroOrMore(expr)
 
 
+ds9_shape_in_comment_defs = dict(text=wcs_shape(CoordOdd, CoordEven),
+                                 vector=wcs_shape(CoordOdd, CoordEven,
+                                                  Distance, Angle),
+                                 composite=wcs_shape(CoordOdd, CoordEven, Angle),
+                                 ruler=wcs_shape(CoordOdd, CoordEven, CoordOdd, CoordEven),
+                                 compass=wcs_shape(CoordOdd, CoordEven, Distance),
+                                 projection=wcs_shape(CoordOdd, CoordEven, CoordOdd, CoordEven, Distance),
+                                 segment=wcs_shape(CoordOdd, CoordEven,
+                                                   repeat=(0, 2)))
+
+
 class Ds9AttrParser(object):
     def set_continued(self, s, l, tok):
         self.continued = True
@@ -35,16 +46,6 @@ class Ds9AttrParser(object):
 
         ds9_attr_parser = get_ds9_attr_parser()
 
-        ds9_shape_in_comment_defs = dict(text=wcs_shape(CoordOdd, CoordEven),
-                                         vector=wcs_shape(CoordOdd, CoordEven,
-                                                          Distance, Angle),
-                                         composite=wcs_shape(CoordOdd, CoordEven, Angle),
-                                         ruler=wcs_shape(CoordOdd, CoordEven, CoordOdd, CoordEven),
-                                         compass=wcs_shape(CoordOdd, CoordEven, Distance),
-                                         projection=wcs_shape(CoordOdd, CoordEven, CoordOdd, CoordEven, Distance),
-                                         segment=wcs_shape(CoordOdd, CoordEven,
-                                                           repeat=(0, 2)),
-                                         )
         regionShape = define_shape_helper(ds9_shape_in_comment_defs)
         regionShape = regionShape.setParseAction(lambda s, l, tok: Shape(tok[0], tok[1:]))
 

--- a/pyregion/ds9_region_parser.py
+++ b/pyregion/ds9_region_parser.py
@@ -13,8 +13,10 @@ from .wcs_converter import (convert_to_imagecoord,
 
 ds9_shape_defs = dict(
     circle=wcs_shape(CoordOdd, CoordEven, Distance),
-    rotbox=wcs_shape(CoordOdd, CoordEven, Distance, Distance, Angle),
-    box=wcs_shape(CoordOdd, CoordEven, Distance, Distance, Angle),
+    rotbox=wcs_shape(CoordOdd, CoordEven, Distance, Distance, Angle,
+                     repeat=(2, 4)),
+    box=wcs_shape(CoordOdd, CoordEven, Distance, Distance, Angle,
+                  repeat=(2, 4)),
     polygon=wcs_shape(CoordOdd, CoordEven, repeat=(0, 2)),
     ellipse=wcs_shape(CoordOdd, CoordEven, Distance, Distance, Angle, repeat=(2, 4)),
     annulus=wcs_shape(CoordOdd, CoordEven, Distance, repeat=(2, 3)),

--- a/pyregion/ds9_region_parser.py
+++ b/pyregion/ds9_region_parser.py
@@ -1,7 +1,9 @@
 import copy
 import warnings
-from pyparsing import (Literal, CaselessKeyword, Optional, And, Or,
-                       StringEnd, ParseException)
+from pyparsing import (Literal, CaselessKeyword, CaselessLiteral,
+                       Optional, And, Or, Word,
+                       StringEnd, ParseException, Combine,
+                       alphas)
 from .region_numbers import CoordOdd, CoordEven, Distance, Angle, Integer
 from .parser_helper import (wcs_shape, define_shape_helper, Shape, Global,
                             RegionPusher, define_expr, define_line,
@@ -59,8 +61,11 @@ class RegionParser(RegionPusher):
                               'J2000', 'GALACTIC', 'ECLIPTIC', 'ICRS',
                               'LINEAR', 'AMPLIFIER', 'DETECTOR']
 
-        coordCommand = define_simple_literals(coord_command_keys,
-                                              parseAction=lambda s, l, tok: CoordCommand(tok[-1]))
+        coordCommandLiterals = define_simple_literals(coord_command_keys)
+        coordCommandWCS = Combine(CaselessLiteral("WCS") + Optional(Word(alphas)))
+
+        coordCommand = (coordCommandLiterals | coordCommandWCS)
+        coordCommand.setParseAction(lambda s, l, tok: CoordCommand(tok[-1]))
 
         regionGlobal = comment_shell_like(CaselessKeyword("global"),
                                           lambda s, l, tok: Global(tok[-1]))

--- a/pyregion/parser_helper.py
+++ b/pyregion/parser_helper.py
@@ -93,7 +93,8 @@ def define_line(atom,
                 comment):
     atomSeparator = separator.suppress()
 
-    atomList = atom + ZeroOrMore(atomSeparator + atom)
+    atomList = atom + ZeroOrMore(atomSeparator + atom) + \
+               Optional(atomSeparator)
 
     line = (atomList + Optional(comment)) | comment
 

--- a/pyregion/wcs_converter.py
+++ b/pyregion/wcs_converter.py
@@ -32,9 +32,15 @@ def _generate_arg_types(coordlist_length, shape_name):
 
     """
     from .ds9_region_parser import ds9_shape_defs
+    from .ds9_attr_parser import ds9_shape_in_comment_defs
 
-    initial_arg_types = ds9_shape_defs[shape_name].args_list
-    arg_repeats = ds9_shape_defs[shape_name].args_repeat
+    if shape_name in ds9_shape_defs:
+        shape_def = ds9_shape_defs[shape_name]
+    else:
+        shape_def = ds9_shape_in_comment_defs[shape_name]
+
+    initial_arg_types = shape_def.args_list
+    arg_repeats = shape_def.args_repeat
 
     if arg_repeats is None:
         return initial_arg_types


### PR DESCRIPTION
This is to improve the grammar coverage. 

* shape definition for "box" and "rotbox" are modified to allow multiple sizes, 

> box(18:13:27.558,+31:22:30.76,13.32",6.66",19.98",9.99",45.2623)

* shape definition for  "ruler" and "compass" are added.

* coordinate command for "wcs" and "wcs[a-z]" are added.

With this, coverage from https://github.com/astropy/regions/blob/master/dev/regions_pyregion_comparison.py
is improved. In fact, only warning issued is for the comment only region. And I believe it gives 100% coverage if we change how the number of regions are counted (https://github.com/astropy/regions/pull/126)
