### PR TITLE
Hex color support in attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ Other Changes and Additions
 
 - Astropy 1.0 is now required.
 
+- Parser supports hex color in attributes
+
 1.2 (Aug 11, 2016)
 ------------------
 

--- a/pyregion/ds9_attr_parser.py
+++ b/pyregion/ds9_attr_parser.py
@@ -13,6 +13,7 @@ def get_ds9_attr_parser():
     lhs = Word(alphas)
     paren = QuotedString("(", endQuoteChar=")")
     rhs = Or([Word(alphas + nums),
+              Combine(Literal("#") + Word(alphas + nums)),  # color with '#'
               Combine(Word(alphas) + White() + Word(nums)),  # for point
               quotedString,
               QuotedString("{", endQuoteChar="}"),

--- a/pyregion/tests/test_ds9_attr_parser.py
+++ b/pyregion/tests/test_ds9_attr_parser.py
@@ -7,6 +7,7 @@ def test_attr():
     assert p.parseString("font=\"123 123\"")[0] == ("font", '"123 123"')
     assert p.parseString("color")[0] == ("color",)
     assert p.parseString("tag={group 1}")[0] == ("tag", "group 1")
+    assert p.parseString('color=#6a8')[0] == ("color", "#6a8")
 
 
 def test_get_attr():


### PR DESCRIPTION
Adjust attribute parser to allow hex color format (e.g., #a4d)
This is to addresses https://github.com/astropy/pyregion/issues/106
