### PR TITLE
Update to astropy.visualization.wcsaxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
-          env: SETUP_CMD='build_docs -w' PIP_DEPENDENCIES='wcsaxes sphinx_rtd_theme'
+          env: SETUP_CMD='build_docs -w' PIP_DEPENDENCIES='sphinx_rtd_theme'
         - python: 3.5
-          env: SETUP_CMD='build_docs -w' PIP_DEPENDENCIES='wcsaxes sphinx_rtd_theme'
+          env: SETUP_CMD='build_docs -w' PIP_DEPENDENCIES='sphinx_rtd_theme'
 
         # Try Astropy development and LTS version
         - python: 2.7

--- a/docs/figures/region_drawing.py
+++ b/docs/figures/region_drawing.py
@@ -9,7 +9,7 @@ f_xray = fits.open(xray_name)
 
 try:
     from astropy.wcs import WCS
-    from wcsaxes import WCSAxes
+    from astropy.visualization.wcsaxes import WCSAxes
 
     wcs = WCS(f_xray[0].header)
     fig = plt.figure()

--- a/docs/figures/region_drawing2.py
+++ b/docs/figures/region_drawing2.py
@@ -9,7 +9,7 @@ f_xray = fits.open(xray_name)
 
 try:
     from astropy.wcs import WCS
-    from wcsaxes import WCSAxes
+    from astropy.visualization.wcsaxes import WCSAxes
 
     wcs = WCS(f_xray[0].header)
     fig = plt.figure()

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,11 @@ Python 2.7 and 3.4+ are supported.
 ``pyregion`` has the following optional dependencies for plotting:
 
 * `matplotlib <http://matplotlib.org/>`__
-* `wcsaxes <https://github.com/astrofrog/wcsaxes>`__
+
+If you are using Astropy version 1.3 or later,
+then you have ``astropy.visualization.wcsaxes``.
+For older versions of Astropy, you have to install the separate package:
+`wcsaxes <https://github.com/astrofrog/wcsaxes>`__
 
 To work with the development version, you'll need Cython and a C compiler,
 because the code to generate masks from regions is written in Cython.

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -3,4 +3,3 @@ matplotlib
 Cython
 astropy-helpers
 astropy
--e git+git://github.com/astrofrog/wcsaxes.git#egg=wcsaxes

--- a/examples/demo_region03.py
+++ b/examples/demo_region03.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid.anchored_artists import AnchoredText
 from astropy.io.fits import Header
 from astropy.wcs import WCS
-from wcsaxes import WCSAxes
+from astropy.visualization.wcsaxes import WCSAxes
 import pyregion
 
 region_list = [


### PR DESCRIPTION
This PR implements #116, i.e. updates from standalone `wcsaxes` to `astropy.visualization.wcsaxes` in the `pyregion` package.

@astrofrog - Is this update OK or can it be done somehow in a better way?

All- The statement in the install docs is that `pyregion` still runs on Astropy >=1 although I'm not sure if it's true. So I don't know if backward compat is an issue here or how far back support for old Astropy versions is desired here. Maybe it would be OK to bump the required version to Astropy >= 1.3?