### PR TITLE
Drop use_2to3, setuptools 58 removed support for it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     cmdclass=cmdclassd,
     zip_safe=False,
-    use_2to3=False,
     classifiers=classifiers,
     **package_info
 )


### PR DESCRIPTION
False was the default, anyway.