### PR TITLE
Fix `import_array()` (Fix #163)

### DIFF
--- a/pyregion/c_numpy.pxd
+++ b/pyregion/c_numpy.pxd
@@ -126,5 +126,14 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_IterNew(object obj)
     void PyArray_ITER_NEXT(flatiter it)
 
-    void import_array()
+    int _import_array() except -1
+    int __pyx_import_array "_import_array"() except -1
+
+
     void import_ufunc()
+
+cdef inline int import_array() except -1:
+    try:
+        __pyx_import_array()
+    except Exception:
+        raise ImportError("numpy._core.multiarray failed to import")


### PR DESCRIPTION
When using Clang as the host compiler, the pip install pyregion command fails, as indicated by issue #163.

<details>
  <summary>Error of `pip install pyregion`</summary>
Collecting pyregion
  Using cached pyregion-2.2.0.tar.gz (978 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: pyparsing>=2.0 in /Users/gen/Library/Application Support/hatch/env/virtual/test/lib/python3.10/site-packages (from pyregion) (3.1.2)
Requirement already satisfied: numpy>=1.16 in /Users/gen/Library/Application Support/hatch/env/virtual/test/lib/python3.10/site-packages (from pyregion) (2.0.0)
Requirement already satisfied: astropy>=4.0 in /Users/gen/Library/Application Support/hatch/env/virtual/test/lib/python3.10/site-packages (from pyregion) (6.1.1)
Requirement already satisfied: pyerfa>=2.0.1.1 in /Users/gen/Library/Application Support/hatch/env/virtual/test/lib/python3.10/site-packages (from astropy>=4.0->pyregion) (2.0.1.4)
Requirement already satisfied: astropy-iers-data>=0.2024.5.27.0.30.8 in /Users/gen/Library/Application Support/hatch/env/virtual/test/lib/python3.10/site-packages (from astropy>=4.0->pyregion) (0.2024.6.24.0.31.11)
Requirement already satisfied: PyYAML>=3.13 in /Users/gen/Library/Application Support/hatch/env/virtual/test/lib/python3.10/site-packages (from astropy>=4.0->pyregion) (6.0.1)
Requirement already satisfied: packaging>=19.0 in /Users/gen/Library/Application Support/hatch/env/virtual/test/lib/python3.10/site-packages (from astropy>=4.0->pyregion) (24.1)
Building wheels for collected packages: pyregion
  Building wheel for pyregion (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for pyregion (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [104 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib.macosx-11.0-arm64-cpython-310
      creating build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/conftest.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/version.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/region_numbers.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/region_to_filter.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/__init__.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/core.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/ds9_region_parser.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/parser_helper.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/wcs_helper.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/mpl_helper.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/ds9_attr_parser.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/physical_coordinate.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/wcs_converter.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      creating build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      copying pyregion/tests/test_ds9_attr_parser.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      copying pyregion/tests/test_cube.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      copying pyregion/tests/test_region_numbers.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      copying pyregion/tests/test_parser_helper.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      copying pyregion/tests/test_region.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      copying pyregion/tests/test_get_mask.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      copying pyregion/tests/test_wcs.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      copying pyregion/tests/test_ds9_region_parser.py -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      running egg_info
      writing pyregion.egg-info/PKG-INFO
      writing dependency_links to pyregion.egg-info/dependency_links.txt
      writing requirements to pyregion.egg-info/requires.txt
      writing top-level names to pyregion.egg-info/top_level.txt
      dependency /private/var/folders/md/4smtqx_56_787wjl_jxqg8mr0000gp/T/pip-build-env-tjkiv29w/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/arrayobject.h won't be automatically included in the manifest: the path must be relative
      ERROR setuptools_scm._file_finders.git listing git files failed - pretending there aren't any
      reading manifest file 'pyregion.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      no previously-included directories found matching 'build'
      no previously-included directories found matching 'docs/_build'
      no previously-included directories found matching 'docs/api'
      adding license file 'LICENSE'
      writing manifest file 'pyregion.egg-info/SOURCES.txt'
      copying pyregion/_region_filter.c -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/_region_filter.pyx -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/c_numpy.pxd -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/c_python.pxd -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/geom.h -> build/lib.macosx-11.0-arm64-cpython-310/pyregion
      copying pyregion/tests/coveragerc -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests
      creating build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/sample_fits01.header -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/sample_fits02.header -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/sample_fits03.header -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/sample_fits04.header -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test.header -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_ciao.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_ciao_physical.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_ds9_physical.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_fk4.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_fk5.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_fk5_degree.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_fk5_sexagecimal.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_gal.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_icrs.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_img.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_mixed.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test01_print.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test02.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test02_1_fk5.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test02_1_img.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test03_ciao_physical.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test03_fk5.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test03_gal.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test03_icrs.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test03_img.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test04_img.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test_annuli.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test_annuli_ciao.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test_annuli_wcs.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test_context.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      copying pyregion/tests/data/test_text.reg -> build/lib.macosx-11.0-arm64-cpython-310/pyregion/tests/data
      running build_ext
      building 'pyregion._region_filter' extension
      creating build/temp.macosx-11.0-arm64-cpython-310
      creating build/temp.macosx-11.0-arm64-cpython-310/pyregion
      clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -arch arm64 -mmacosx-version-min=11.0 -Wno-nullability-completeness -Wno-expansion-to-defined -Wno-undef-prefix -fPIC -Werror=unguarded-availability-new -I/private/var/folders/md/4smtqx_56_787wjl_jxqg8mr0000gp/T/pip-build-env-tjkiv29w/overlay/lib/python3.10/site-packages/numpy/core/include "-I/Users/gen/Library/Application Support/hatch/env/virtual/test/include" "-I/Users/gen/Library/Application Support/hatch/pythons/3.10/python/include/python3.10" -c pyregion/_region_filter.c -o build/temp.macosx-11.0-arm64-cpython-310/pyregion/_region_filter.o
      In file included from pyregion/_region_filter.c:1242:
      In file included from /private/var/folders/md/4smtqx_56_787wjl_jxqg8mr0000gp/T/pip-build-env-tjkiv29w/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/arrayobject.h:4:
      In file included from /private/var/folders/md/4smtqx_56_787wjl_jxqg8mr0000gp/T/pip-build-env-tjkiv29w/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/ndarrayobject.h:12:
      In file included from /private/var/folders/md/4smtqx_56_787wjl_jxqg8mr0000gp/T/pip-build-env-tjkiv29w/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/ndarraytypes.h:1969:
      /private/var/folders/md/4smtqx_56_787wjl_jxqg8mr0000gp/T/pip-build-env-tjkiv29w/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: "Using deprecated NumPy API, disable it with "          "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-W#warnings]
      #warning "Using deprecated NumPy API, disable it with " \
       ^
      pyregion/_region_filter.c:18294:3: error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'int' [-Wint-conversion]
        import_array();
        ^~~~~~~~~~~~~~
      /private/var/folders/md/4smtqx_56_787wjl_jxqg8mr0000gp/T/pip-build-env-tjkiv29w/overlay/lib/python3.10/site-packages/numpy/core/include/numpy/__multiarray_api.h:1532:151: note: expanded from macro 'import_array'
      #define import_array() {if (_import_array() < 0) {PyErr_Print(); PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import"); return NULL; } }
                                                                                                                                                            ^~~~
      /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/15.0.0/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      1 warning and 1 error generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pyregion
Failed to build pyregion
ERROR: Could not build wheels for pyregion, which is required to install pyproject.toml-based projects
</details>

This issue comes up because in GCC, `NULL` is defined as `0`, while in Clang it is defined as `(void *)0`. Just like numpy did in their code [here](https://github.com/numpy/numpy/blob/0acdad6c8b7808e0cc6ce19523e2150b3fb72b27/numpy/__init__.cython-30.pxd#L1021-L1025), it would be good to define `import_array()` as a function that returns an int.