### PR TITLE
Deprecation and archiving of this package/repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 pyregion
 ========
 
+DEPRECATION note
+----------------
+pyregion is deprecated in favor of astropy regions (https://astropy-regions.readthedocs.io/en/stable/), as pyregion is no longer maintained.
+
+Historic Documentation
+----------------------
 pyregion is a python module to parse ds9 region files.
 It also supports ciao region files.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,14 +5,16 @@ pyregion
 :Release: |version|
 :Date: |today|
 
-pyregion is a python module to parse ds9 region files.
-It also supports ciao region files.
 
 .. note::
 
-    See also the in-development ``regions`` package
+    The ``regions`` package
     at https://github.com/astropy/regions
-    a new astronomy package for regions based on Astropy.
+    supercedes pyregion.
+    The pyregion package is deprecated and unmaintained.
+
+pyregion is a python module to parse ds9 region files.
+It also supports ciao region files.
 
 
 +----------------------------------------+----------------------------------------+

--- a/pyregion/core.py
+++ b/pyregion/core.py
@@ -3,7 +3,11 @@ from itertools import cycle
 from .ds9_region_parser import RegionParser
 from .wcs_converter import check_wcs as _check_wcs
 
+from warnings import DeprecationWarning, warn
+
 _builtin_open = open
+
+warn("The pyregion package is deprecated.  Please switch to astropy regions.", DeprecationWarning)
 
 
 class ShapeList(list):


### PR DESCRIPTION
cc @astrofrog @leejjoon 

At the astropy coordination meeting, we discussed the status of the pyregion package.  I think it is not being maintained any longer, and all of our effort has moved over to astropy regions.

This should be the last PR merged on pyregion.  After that, we should close all the issues & PRs and archive the repository.

### TODO

- [ ] Coordinate with other maintainers.
- [ ] Update docs (README and RTD) with banner indicating that package is deprecated. (This PR)
- [ ] If RTD has multiple versions, make sure only the one with deprecated message is active. Check the RTD admin panel.
- [ ] Close all open issues and PRs as "won't fix".
- [ ] Does it need one last release on PyPI?
- [ ] Archive this GitHub repository.
- [ ] Mark PyPI page (https://pypi.org/project/pyregion/) as archived. PyPI project admin has to do this one. 